### PR TITLE
Delayed channel reset

### DIFF
--- a/mpdcast_dab/__main__.py
+++ b/mpdcast_dab/__main__.py
@@ -54,7 +54,7 @@ def update_logger_config(verbose):
 
 def get_args():
   parser = argparse.ArgumentParser(description='MPD Cast Device Agent',
-	                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+                                   formatter_class=argparse.ArgumentDefaultsHelpFormatter)
   parser.add_argument('-p', '--port', help= 'Communication port to use.', type=int, default=8864)
   parser.add_argument('-c', '--conf', help= 'MPD config file to use.', default='/etc/mpd.conf')
   parser.add_argument('--disable-dabserver', help= 'Disable DAB server functionality', action='store_true')

--- a/mpdcast_dab/welle_python/radio_controller.py
+++ b/mpdcast_dab/welle_python/radio_controller.py
@@ -75,7 +75,6 @@ class RadioController(RadioControllerInterface):
     # Not found
     return None
 
-
   async def _wait_for_channel(self, program_name):
     # initial check, as we might already have an active subscription for the program
     program_pid = self._get_program_id(program_name)
@@ -91,7 +90,6 @@ class RadioController(RadioControllerInterface):
         return program_pid
     # Not found
     return None
-
 
   # returns handler in case the subscription suceeded, otherwise None
   async def subscribe_program(self, channel, program_name):

--- a/mpdcast_dab/welle_python/radio_controller.py
+++ b/mpdcast_dab/welle_python/radio_controller.py
@@ -102,12 +102,11 @@ class RadioController(RadioControllerInterface):
     # first check, if there is a delayed channel reset pending
     if not self._cancel_delayed_channel_reset.is_set():
       # we have an active channel, check if we can reuse it
-      if self._channel.name == channel:
-        # yes, we can. So notify to cancel the reset
-        self._cancel_delayed_channel_reset.set()
-      else:
+      if self._channel.name != channel:
         # no, we cant. reset channel immediately, so we can select a new one afterwards
         self._reset_channel()
+      # we either reuse the channel or we resetted it. In both cases: Canncel the delayed reset
+      self._cancel_delayed_channel_reset.set()
 
     # If there is a channel active, check if its the correct one
     if self._channel.name:

--- a/mpdcast_dab/welle_python/radio_controller.py
+++ b/mpdcast_dab/welle_python/radio_controller.py
@@ -34,6 +34,17 @@ class RadioController(RadioControllerInterface):
     self._current_channel = ''
     self.ensemble_label   = None
     self.datetime         = None
+
+    '''
+    event _cancel_delayed_unsubscribe will:
+     not be set (or cleared) when we wait for somebody to cancel a delayed unsubscribe
+     set when the unsubscribe
+      -shall be cancelled or
+      -there is no delayed unsubscribe pending
+     awaited to be set during a potential unsubscription cancel:
+     event set => the unsubscribe was cancelled, so dont reset
+     Timeout => unsubscribe was not cancelled, so reset (or dont in case someone did an immediate unsubscribe)
+    '''
     self._cancel_delayed_unsubscribe = asyncio.Event()
     self._cancel_delayed_unsubscribe.set()
 


### PR DESCRIPTION
New feature: Execute channel de-selects with 5 seconds delay to allow re-using them eg during switches from the same player.
This avoids unnecessary reset and re-tune of the channel again, making the channel switch significantly faster