### PR TITLE
Add missing dependencies to Debian package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Homepage: https://github.com/Lamarqe/mpdcast-dab
 
 Package: mpdcast-dab
 Architecture: any
-Depends: librtlsdr2, mpd, python3-mpd, python3-aiohttp, python3-pychromecast
+Depends: librtlsdr2, mpd, python3-mpd, python3-aiohttp, python3-pychromecast, libpython3.12, libfftw3-single3
 Description: MPD to Google cast streaming application
  MPD to Google cast streaming application with support for DAB+ radio 


### PR DESCRIPTION
This resolves the missing dependencies to:

- libpython3.12
- libfftw3